### PR TITLE
Use $app->end instead of die on redirect

### DIFF
--- a/src/FallbackSite.php
+++ b/src/FallbackSite.php
@@ -124,7 +124,7 @@ class FallbackSite extends Plugin
 					$originalelement = Craft::$app->getElements()->getElementById($element->id, null, $originalsite->id);
 					if ($originalelement && $originalelement->getStatus() == 'live') { // Found an element with a different slug that is available.
 						Craft::$app->getResponse()->redirect($originalelement->getUrl(), 301); // Redirect to the proper element.
-						die(); // Redirect immediately, do not let Craft fall back to default 404 behavior (which wipes out the redirect).
+						Craft::$app->end(); // Redirect immediately, do not let Craft fall back to default 404 behavior (which wipes out the redirect).
 					} else {
 						// Do some reflection **magic** to substitute the element and route with the cached ones in Craft's UrlManager.
 						// This is required because there is no other way to clear this cache short of replacing the UrlManager component


### PR DESCRIPTION
Hey there!

I was getting blank pages on redirects. I swapped out the `die()` for `Craft::$app->end()` and it works as expected. Cheers!